### PR TITLE
Update for 3x3 maze demos

### DIFF
--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -338,9 +338,15 @@ fn main() -> ! {
             green_led.toggle();
 
             if plan.control().is_idle() {
-                blue_led.set_low();
+                orange_led.set_low();
             } else {
+                orange_led.set_high();
+            }
+
+            if plan.is_win() {
                 blue_led.set_high();
+            } else {
+                blue_led.set_low();
             }
 
             if battery.is_dead() {

--- a/firmware/src/plan.rs
+++ b/firmware/src/plan.rs
@@ -169,6 +169,10 @@ where
     pub fn direction(&self) -> Direction {
         self.direction
     }
+
+    pub fn is_win(&self) -> bool {
+        self.x_pos == 1 && self.y_pos == 1
+    }
 }
 
 impl<N> Command for Plan<N>


### PR DESCRIPTION
Various updates that were used for demos
 - Parameterize maze size and change to 3x3 cells
 - Add is_win to check if it is in the winning square
 - Make LEDs more useful